### PR TITLE
Add __future__ print functions

### DIFF
--- a/Scripts/mail_sniffer.py
+++ b/Scripts/mail_sniffer.py
@@ -1,4 +1,5 @@
 from scapy.all import *
+from __future__ import print_function
 
 # our packet callback
 def packet_callback(packet):
@@ -6,8 +7,8 @@ def packet_callback(packet):
         mail_packet = str(packet[TCP].payload)
 
         if "user" in mail_packet.lower() or "pass" in mail_packet.lower():
-            print "[*] Server: %s" % packet[IP].dst
-            print "[*] %s" % packet[TCP].payload
+            print("[*] Server: %s" % packet[IP].dst)
+            print("[*] %s" % packet[TCP].payload)
 
 # fire up our sniffer
 sniff(filter="tcp port 110 or tcp port 25 or tcp port 143",


### PR DESCRIPTION
Add in the print() to a function call, to be compatible with Python 3 and use from __future__ import print_function to keep python 2 computability.